### PR TITLE
fix: wrong currency format

### DIFF
--- a/src/csfloat/content_script.ts
+++ b/src/csfloat/content_script.ts
@@ -1495,7 +1495,8 @@ function getFloatItem(container: Element): CSFloat.FloatItem {
     const header_details = <Element>nameContainer?.childNodes[1];
 
     const name = nameContainer?.querySelector('.item-name')?.textContent?.replace('\n', '').trim();
-    let priceText = priceContainer?.textContent?.trim().split(/\s/) ?? [];
+    const regex = /([A-Za-z]+)\s+(\d+)/;
+    let priceText = priceContainer?.textContent?.trim().replace(regex, '$1$2').split(/\s/) ?? [];
     let price: string;
     let currency = '$';
     if (location.pathname === '/sell') {


### PR DESCRIPTION
Fixed a minor issue that was breaking the extension for currencies such as ```AED```, ```CHF```, ```DKK```, ```NOK```, ```PLN```, and ```SAB```, which was caused by the spaces between their symbols and numbers, instead of them being directly next to each other.

![image](https://github.com/GODrums/BetterFloat/assets/43102929/d59d010b-5666-4c25-91dc-3d335830cb36)
![image](https://github.com/GODrums/BetterFloat/assets/43102929/61f0ee8a-520b-4cc1-9718-8a9f001718f1)

![image](https://github.com/GODrums/BetterFloat/assets/43102929/4340bf0f-65c0-4b87-a074-4d34860e5106)
![image](https://github.com/GODrums/BetterFloat/assets/43102929/e659e062-1e50-468e-bcf1-d52a7bf590fa)


We can easily resolve this and obtain the correct format by eliminating the mentioned space.

```typescript
const regex = /([A-Za-z]+)\s+(\d+)/;
let priceText = priceContainer?.textContent?.trim().replace(regex, '$1$2').split(/\s/) ?? [];
```

![image](https://github.com/GODrums/BetterFloat/assets/43102929/64d2f030-2f10-4e5c-88f7-64e85c8332ca)