### PR TITLE
fix: sp% for currencies other than USD

### DIFF
--- a/src/csfloat/content_script.ts
+++ b/src/csfloat/content_script.ts
@@ -669,13 +669,13 @@ async function adjustSalesTableRow(container: Element) {
         const priceData = JSON.parse(document.querySelector('.betterfloat-big-price')?.getAttribute('data-betterfloat') ?? '');
         const sellPrice = Number(container.querySelector('.mat-column-price')?.textContent?.replace(/[^0-9.]/g, ''));
         const currencyRate = await getCSFCurrencyRate(CSFloatHelpers.userCurrency)
-        const priceDiffUSD = (sellPrice - Number(priceData.priceFromReference)) / currencyRate
 
         if (priceData && stickerData.length > 0) {
             const stickerContainer = document.createElement('div');
             stickerContainer.className = 'betterfloat-table-sp';
             (<HTMLElement>appStickerView).style.display = 'flex';
             (<HTMLElement>appStickerView).style.alignItems = 'center';
+            const priceDiffUSD = (sellPrice - Number(priceData.priceFromReference)) / currencyRate
             const doChange = await changeSpContainer(stickerContainer, stickerData, priceDiffUSD);
             if (doChange) {
                 appStickerView.appendChild(stickerContainer);


### PR DESCRIPTION
Fixed a bug where the SP% was significantly inaccurate for every currency other than USD. The current implementation used the display price on float, regardless of its currency:

```typescript
const sellPrice = Number(container.querySelector('.mat-column-price')?.textContent?.replace('$', ''));
```


It also compared it to price values in USD, if it was even able to extract the number correctly. This issue applied to all instances of the SP container (popout, sales history, etc.), leading to discrepancies between currencies:

![image](https://github.com/GODrums/BetterFloat/assets/43102929/400a3738-15bc-456f-8b06-544dadfbaf35) ![image](https://github.com/GODrums/BetterFloat/assets/43102929/52bd1bc7-4c96-4f91-a172-2c8bea02add1)

![image](https://github.com/GODrums/BetterFloat/assets/43102929/d03415a9-91dc-44a4-852c-9062bf204265)
![image](https://github.com/GODrums/BetterFloat/assets/43102929/2b2e3806-f4eb-43ae-b618-1e13e910cdd4)

The proposed solution involves dividing the user's local currency by its rate vs USD, ensuring it matches Buff's USD price:

```typescript
const currencyRate = await getCSFCurrencyRate(CSFloatHelpers.userCurrency) 
const priceResultUSD = priceResult.price_difference / currencyRate
```

While the SP% in the sales history is still somewhat inaccurate (as it occasionally compares months-old transactions in today's market), it will now hold true regardless of the user's currency:

![image](https://github.com/GODrums/BetterFloat/assets/43102929/9c5727fe-553a-404b-b330-02353ec0039b)
