### PR TITLE
Fix CSFloat listing age tooltip clipping

### DIFF
--- a/src/css/csfloat_styles.css
+++ b/src/css/csfloat_styles.css
@@ -12,6 +12,17 @@ app-user-orders {
 	}
 }
 
+.betterfloat-listing-age {
+	position: relative;
+	z-index: 1;
+}
+
+item-card:has(.betterfloat-listing-age:hover),
+.item-card:has(.betterfloat-listing-age:hover) {
+	position: relative;
+	z-index: 20;
+}
+
 .betterfloat-buff-a {
 	display: inline-flex;
 	align-items: center;


### PR DESCRIPTION
## Summary
- Raise the hovered CSFloat listing card while the BetterFloat listing-age tooltip is active.
- Keep the existing hint.css tooltip placement and styling unchanged.
- Scope the stacking change to `.betterfloat-listing-age` inside CSFloat item cards.

## Root Cause
The listing-age tooltip is rendered with an absolutely positioned hint.css pseudo-element inside the listing card. Adjacent listing cards can paint above it, clipping or covering the date tooltip when cards sit next to each other.
<img width="520" height="263" alt="image" src="https://github.com/user-attachments/assets/8849e650-f64f-4428-a054-e1e8f70a9f47" />


## Validation
- Manually verified on csfloat.com that injecting the same CSS makes the full date tooltip render above adjacent listings.
- `npx --yes pnpm@10.33.0 exec biome ci src/css/csfloat_styles.css` passes.

## Notes
- Full `pnpm lint` currently fails on existing unrelated repo-wide Biome issues in other files.
- Full `pnpm build` reaches Plasmo but fails in this public checkout because `~lib/handlers/selectors/skinout_selectors` is missing from `src/contents/haloskins/index.ts`.